### PR TITLE
feat: add summary.csv export alongside JSON results

### DIFF
--- a/src/htmlminer/main.py
+++ b/src/htmlminer/main.py
@@ -20,7 +20,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 from .crawler import crawl_domain, fetch_firecrawl_map_urls, fetch_sitemap_urls, scrape_firecrawl_urls
 from .agent import AgenticExtractor, MODEL_TIERS
 from .firecrawl_agent import FirecrawlAgentExtractor, SPARK_MODELS
-from .storage import save_results, display_results
+from .storage import save_results, display_results, save_summary_csv
 
 from .database import init_db, create_session, log_event, save_extractions
 
@@ -546,6 +546,11 @@ def process(
     save_results(results, output, metadata=metadata)
     save_extractions(results, session_id)
     console.print(f"\n[bold green]✓[/bold green] Results saved to [bold]{output}[/bold]")
+
+    # Export summary CSV
+    summary_csv_path = "summary.csv"
+    save_summary_csv(results, summary_csv_path)
+
     display_results(results)
     
     # Token Usage stats (only for standard extraction mode)

--- a/src/htmlminer/storage.py
+++ b/src/htmlminer/storage.py
@@ -36,6 +36,47 @@ def save_results(results: List[Dict], output_file: str, metadata: Optional[Dict]
         
     console.print(f"[green]Results saved to {output_file}[/green]")
 
+def save_summary_csv(results: List[Dict], output_file: str):
+    """
+    Saves a summary CSV with URL, feature columns, and a counts column.
+    This matches the CLI table format.
+    """
+    if not results:
+        console.print("[yellow]No results to save.[/yellow]")
+        return
+
+    # Extract feature names (excluding special fields)
+    known_fields = {"URL", "Raw_Extractions"}
+    feature_names = []
+    for res in results:
+        for k in res.keys():
+            if k not in known_fields and k not in feature_names and not k.endswith("_Raw") and not k.endswith("_Count"):
+                feature_names.append(k)
+
+    # Build CSV data
+    csv_data = []
+    for res in results:
+        row = {"URL": res.get("URL", "N/A")}
+
+        # Add feature columns
+        for feature in feature_names:
+            row[feature] = res.get(feature, "-")
+
+        # Build counts column
+        counts = []
+        for feature in feature_names:
+            count = res.get(f"{feature}_Count", 0)
+            if count > 0:
+                counts.append(f"{feature}: {count}")
+        row["Counts"] = ", ".join(counts) if counts else "0"
+
+        csv_data.append(row)
+
+    # Save to CSV
+    df = pd.DataFrame(csv_data)
+    df.to_csv(output_file, index=False)
+    console.print(f"[green]Summary saved to {output_file}[/green]")
+
 def display_results(results: List[Dict]):
     """
     Displays the results in a Rich table with dynamic columns.
@@ -47,45 +88,45 @@ def display_results(results: List[Dict]):
 
     # Fixed columns
     table.add_column("URL", style="cyan", no_wrap=True)
-    
+
     # Dynamic columns
     # We'll take the keys from the first result, excluding known fixed fields
     known_fields = {"URL", "Raw_Extractions"}
-    
+
     # Gather all potential keys from all results to be safe, or just first one
     all_keys = []
     for res in results:
         for k in res.keys():
             if k not in known_fields and k not in all_keys and not k.endswith("_Raw") and not k.endswith("_Count"):
                 all_keys.append(k)
-    
+
     # Sort or keep order? 'Risk', 'Goal', 'Method' usually come in that order if config preserves it.
     # We'll trust the insertion order (Python dicts preserve order).
-    
+
     for key in all_keys:
         table.add_column(key, style="magenta")
-        
+
     table.add_column("Counts", justify="right")
 
     for res in results:
         row_values = [res.get("URL", "N/A")]
-        
+
         for key in all_keys:
             val = res.get(key, "-")
             # Truncate for display
             display_val = (val[:200] + "...") if len(val) > 200 else val
             row_values.append(display_val)
-            
+
         # Build counts string
         counts = []
         for key in all_keys:
              count = res.get(f"{key}_Count", 0)
              if count > 0:
                  counts.append(f"{key}: {count}")
-        
+
         counts_str = ", ".join(counts) if counts else "0"
         row_values.append(counts_str)
-        
+
         table.add_row(*row_values)
 
     console.print(table)


### PR DESCRIPTION
Add automatic export of summary.csv that includes:
- URL column
- Feature columns (from config.json) pivoted wide
- Counts column showing extraction counts per feature

This CSV matches the CLI table format and is automatically
saved as summary.csv whenever the process command completes.